### PR TITLE
update scripts to use python 3.10 for android & 3.9 for ios

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,19 +23,15 @@ TEST=${TEST:="SampleAppTest"}
 echo "Extracting tests.zip..."
 unzip tests.zip
 
-echo "Installing pip for python"
-python -m venv .venv
-source .venv/bin/activate
-
 echo "Installing pip requirements"
 chmod 0755 requirements.txt
-apt-get --assume-yes install python3.7
+apt-get --assume-yes install python3.10
 python3 --version
-python3.7 --version
-python3.7 -m pip install --upgrade pip
-python3.7 -m pip install wheel
-python3.7 -m pip install -r requirements.txt
-python3.7 -m pip list
+python3.10 --version
+python3.10 -m pip install --upgrade pip
+python3.10 -m pip install wheel
+python3.10 -m pip install -r requirements.txt
+python3.10 -m pip list
 
 echo "Starting Appium ..."
 appium --log-no-colors --log-timestamp  --command-timeout 60  > appium.log 2>&1 &
@@ -47,16 +43,7 @@ export APPIUM_APPFILE=$PWD/application.apk #App file is at current working folde
 
 ## Run the test:
 echo "Running tests"
-
-# rm -rf screenshots
-# /test/.venv/bin/python -m pytest tests/ --junitxml=test-reports/report.xml
-
-# mv test-reports/*.xml TEST-all.xml
-## Run the test:
-
 rm -rf screenshots
-ls -la
-pwd
-python3.7 -m pytest -s tests/ --junitxml=test-reports/report.xml
+python3.10 -m pytest -s tests/ --junitxml=test-reports/report.xml
 
 mv test-reports/*.xml TEST-all.xml

--- a/run-tests_android.sh
+++ b/run-tests_android.sh
@@ -25,13 +25,13 @@ unzip tests.zip
 
 echo "Installing pip requirements"
 chmod 0755 requirements.txt
-apt-get --assume-yes install python3.7
+apt-get --assume-yes install python3.10
 python3 --version
-python3.7 --version
-python3.7 -m pip install --upgrade pip
-python3.7 -m pip install wheel
-python3.7 -m pip install -r requirements.txt
-python3.7 -m pip list
+python3.10 --version
+python3.10 -m pip install --upgrade pip
+python3.10 -m pip install wheel
+python3.10 -m pip install -r requirements.txt
+python3.10 -m pip list
 
 echo "Starting Appium ..."
 appium --log-no-colors --log-timestamp  --command-timeout 60  > appium.log 2>&1 &
@@ -44,6 +44,6 @@ export APPIUM_APPFILE=$PWD/application.apk #App file is at current working folde
 ## Run the test:
 echo "Running tests"
 rm -rf screenshots
-python3.7 -m pytest -s tests/ --junitxml=test-reports/report.xml
+python3.10 -m pytest -s tests/ --junitxml=test-reports/report.xml
 
 mv test-reports/*.xml TEST-all.xml

--- a/run-tests_ios.sh
+++ b/run-tests_ios.sh
@@ -8,13 +8,13 @@ unzip -o tests.zip
 
 echo "Installing pip requirements"
 chmod 0755 requirements.txt
-apt-get --assume-yes install python3.7
+apt-get --assume-yes install python3.9
 python3 --version
-python3.7 --version
-python3.7 -m pip install --upgrade pip
-python3.7 -m pip install wheel
-python3.7 -m pip install -r requirements.txt
-python3.7 -m pip list
+python3.9 --version
+python3.9 -m pip install --upgrade pip
+python3.9 -m pip install wheel
+python3.9 -m pip install -r requirements.txt
+python3.9 -m pip list
 
 #########################################################
 #
@@ -52,6 +52,6 @@ iproxy --version
 ## Start test execution
 ## Run the test:
 echo "Running tests"
-python3.7 -m pytest -s tests/ --junitxml=test-reports/report.xml
+python3.9 -m pytest -s tests/ --junitxml=test-reports/report.xml
 
 mv test-reports/*.xml TEST-all.xml


### PR DESCRIPTION
Tested with: 
- py 3.10 and was ✅  all test were executed
- py 3.11 and got other err: 
![image](https://github.com/alttester/EXAMPLES-Python-Bitbar-AltTrashCat/assets/62647565/32936e45-3428-49eb-a7ba-2fec29abd5a4)
